### PR TITLE
Update @nestjs/terminus version range in package.json

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -36,7 +36,7 @@
     "@nestjs/microservices": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.0.2",
-    "@nestjs/terminus": "^10.0.1|^11.0.1",
+    "@nestjs/terminus": "^10.0.1 || ^11.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -36,7 +36,7 @@
     "@nestjs/microservices": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.0.2",
-    "@nestjs/terminus": "^10.0.1",
+    "@nestjs/terminus": "^10.0.1|^11.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },


### PR DESCRIPTION
Allow terminus 11 to be used as a peer dependency.